### PR TITLE
Pass kwargs to the dependence plot

### DIFF
--- a/probatus/interpret/model_interpret.py
+++ b/probatus/interpret/model_interpret.py
@@ -460,7 +460,7 @@ class ShapModelInterpreter(BaseFitComputePlotClass):
             ax = []
             for feature_name in target_columns:
                 ax.append(
-                    target_tdp.plot(feature=feature_name, figsize=(10, 7), show=show)
+                    target_tdp.plot(feature=feature_name, figsize=(10, 7), show=show, **plot_kwargs)
                 )
 
         elif plot_type == "sample":


### PR DESCRIPTION
Currently, the plot method does not pass the `plot_kwargs` to the dependence plot. That is why the users are not able to modify the default parameters of it. After this change the users can pass e.g. `bins=50` to plot method.