### PR TITLE
Add util function to get SHAP values via CV

### DIFF
--- a/probatus/utils/__init__.py
+++ b/probatus/utils/__init__.py
@@ -28,7 +28,7 @@ from .arrayfuncs import (
     preprocess_data,
     preprocess_labels,
 )
-from .shap_helpers import shap_calc, shap_to_df, calculate_shap_importance
+from .shap_helpers import shap_calc, shap_to_df, calculate_shap_importance, get_shap_cv_values
 from .warnings import ApproximationWarning
 from ._utils import (
     class_name_from_object,
@@ -63,4 +63,5 @@ __all__ = [
     "BaseFitComputeClass",
     "BaseFitComputePlotClass",
     "get_single_scorer",
+    "get_shap_cv_values",
 ]


### PR DESCRIPTION
# Motivation

SHAP values provide an excellent way to estimate model feature importance. The SHAP values tell us how much a feature contributes to (impacts) the model prediction.

When we evaluate model performance, we typically want to know the performance on different data sets:

* train
* validation (val)
* test

Similarly, when we calculate SHAP values, we want to know the impact of the features when the model is applied to different data sets.

With the current `shap` API, it is straightforward to calculate SHAP values for train, val, and test sets.

However, most modeling problems involve limited data, so designating both a val and test set is unacceptable, because too little data is left to train the model. Enter cross validation, of course, where there is no hold-out val set, but the validation occurs via CV on the train set.

With the current `shap` API, there is no support for calculating SHAP values via CV (e.g. by integration with `sklearn`).

So we have three options:

* Calculate SHAP values on train. But this is as flawed as evaluating model performance on train alone. You will get the importance of features of a model trained and evaluated on the same data, i.e. it is not a fair evaluation.
* Calculate SHAP values on test. This seems like a better choice, but if we are calculating SHAP values as a way of selecting model features, it seems a dangerous choice. Ideally, modeling decisions should never be based on the hold-out test set -- that's why we have val sets and CV after all.
* Calculate SHAP values on train via CV. Sounds ideal! But how?
This PR provides a helper function to calculate SHAP values via CV.

Possible contribution to `probatus.utils.shap_helpers` if `probatus` maintainers see value and agree.

`ShapRFECV` is still the better option overall, but for some users a recursive approach may not be feasible due to computational cost. With `get_shap_cv_value`, user gets the benefit of CV in a non-recursive approach and can then select the `n` top features in more confidence.