### PR TITLE
Temporarily fix tests, disable shap 0.40.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ base_packages = [
     "scipy>=1.4.0",
     "joblib>=0.13.2",
     "tqdm>=4.41.0",
-    "0.40.0>shap>=0.38.1",# 0.40.0 causes issues in certain plots. For now it is excluded
+    "shap >= 0.38.1, < 0.39.0",# 0.40.0 causes issues in certain plots. For now it is excluded
     "numpy>=1.19.0",
 ]
 


### PR DESCRIPTION
Temporarily fix tests, disable shap 0.40.0 since it has missing import in one of the plots