### PR TITLE
170 fix shap error cat features

### DIFF
--- a/probatus/utils/shap_helpers.py
+++ b/probatus/utils/shap_helpers.py
@@ -85,8 +85,8 @@ def shap_calc(
         if verbose <= 100:
             warnings.simplefilter("ignore")
 
-
-        # For tree-explainers allow for using check_additivity and approximate arguments
+        # For tree explainers, avoid using masker, related to issue:
+        # https://github.com/slundberg/shap/issues/480
         if Tree.supports_model_with_masker(model, masker=None):
             # Calculate Shap values.
             explainer = Explainer(model, **shap_kwargs)
@@ -95,7 +95,8 @@ def shap_calc(
             # Calculate Shap values.
 
             # Create the background data,required for non tree based models.
-            # A single datapoint can passed as mask (https://github.com/slundberg/shap/issues/955#issuecomment-569837201)
+            # A single datapoint can passed as mask
+            # (https://github.com/slundberg/shap/issues/955#issuecomment-569837201)
             if X.shape[0] < sample_size:
                 sample_size = int(np.ceil(X.shape[0] * 0.2))
             else:

--- a/probatus/utils/shap_helpers.py
+++ b/probatus/utils/shap_helpers.py
@@ -85,15 +85,13 @@ def shap_calc(
         if verbose <= 100:
             warnings.simplefilter("ignore")
 
-        # For tree explainers, avoid using masker, related to issue:
+        # For tree explainers, do not pass masker when feature_perturbation is
+        # tree_path_dependent, related to issue:
         # https://github.com/slundberg/shap/issues/480
-        if Tree.supports_model_with_masker(model, masker=None):
+        if shap_kwargs.get("feature_perturbation") == "tree_path_dependent":
             # Calculate Shap values.
             explainer = Explainer(model, **shap_kwargs)
-            shap_values = explainer.shap_values(X, check_additivity=check_additivity, approximate=approximate)
         else:
-            # Calculate Shap values.
-
             # Create the background data,required for non tree based models.
             # A single datapoint can passed as mask
             # (https://github.com/slundberg/shap/issues/955#issuecomment-569837201)
@@ -103,6 +101,13 @@ def shap_calc(
                 pass
             mask = sample(X, sample_size)
             explainer = Explainer(model, masker=mask, **shap_kwargs)
+
+        # For tree-explainers allow for using check_additivity and approximate arguments
+        if isinstance(explainer, Tree):
+            # Calculate Shap values
+            shap_values = explainer.shap_values(X, check_additivity=check_additivity, approximate=approximate)
+        else:
+            # Calculate Shap values
             shap_values = explainer.shap_values(X)
 
         if isinstance(shap_values, list) and len(shap_values) == 2:

--- a/probatus/utils/shap_helpers.py
+++ b/probatus/utils/shap_helpers.py
@@ -86,9 +86,10 @@ def shap_calc(
             warnings.simplefilter("ignore")
 
         # For tree explainers, do not pass masker when feature_perturbation is
-        # tree_path_dependent, related to issue:
+        # tree_path_dependent, or when X contains categorical features
+        # related to issue:
         # https://github.com/slundberg/shap/issues/480
-        if shap_kwargs.get("feature_perturbation") == "tree_path_dependent":
+        if shap_kwargs.get("feature_perturbation") == "tree_path_dependent" or X.select_dtypes("category").shape[1] > 0:
             # Calculate Shap values.
             explainer = Explainer(model, **shap_kwargs)
         else:

--- a/probatus/utils/shap_helpers.py
+++ b/probatus/utils/shap_helpers.py
@@ -85,31 +85,23 @@ def shap_calc(
         if verbose <= 100:
             warnings.simplefilter("ignore")
 
-        # Create the background data,required for non tree based models.
-        # A single datapoint can passed as mask (https://github.com/slundberg/shap/issues/955#issuecomment-569837201)
-
-        if X.shape[0] < sample_size:
-            sample_size = int(np.ceil(X.shape[0] * 0.2))
-        else:
-            pass
-        mask = sample(X, sample_size)
-
-        if X.select_dtypes("category").shape[1] > 0:
-            if verbose > 0:
-                warnings.warn(
-                    "Using tree_dependent feature_perturbation (in shap) without background"
-                    " data for tree-based model with categorical features."
-                )
-            explainer = Explainer(model, **shap_kwargs)
-        else:
-            explainer = Explainer(model, masker=mask, **shap_kwargs)
 
         # For tree-explainers allow for using check_additivity and approximate arguments
-        if isinstance(explainer, Tree):
+        if Tree.supports_model_with_masker(model, masker=None):
             # Calculate Shap values.
+            explainer = Explainer(model, **shap_kwargs)
             shap_values = explainer.shap_values(X, check_additivity=check_additivity, approximate=approximate)
         else:
             # Calculate Shap values.
+
+            # Create the background data,required for non tree based models.
+            # A single datapoint can passed as mask (https://github.com/slundberg/shap/issues/955#issuecomment-569837201)
+            if X.shape[0] < sample_size:
+                sample_size = int(np.ceil(X.shape[0] * 0.2))
+            else:
+                pass
+            mask = sample(X, sample_size)
+            explainer = Explainer(model, masker=mask, **shap_kwargs)
             shap_values = explainer.shap_values(X)
 
         if isinstance(shap_values, list) and len(shap_values) == 2:

--- a/tests/feature_elimination/test_feature_elimination.py
+++ b/tests/feature_elimination/test_feature_elimination.py
@@ -569,10 +569,7 @@ def test_EarlyStoppingShapRFECV_no_categorical(complex_data):
     )
     X, y = complex_data
     X = X.drop(columns=["f1_categorical"])
-    report = shap_elimination.fit_compute(
-        X,
-        y,
-    )
+    report = shap_elimination.fit_compute(X, y, feature_perturbation="tree_path_dependent")
     assert shap_elimination.fitted
     shap_elimination._check_if_fitted()
 
@@ -615,10 +612,7 @@ def test_LightGBM_stratified_kfold():
             eval_metric="logloss",
             early_stopping_rounds=5,
         )
-        report = shap_elimination.fit_compute(
-            X,
-            y,
-        )
+        report = shap_elimination.fit_compute(X, y, feature_perturbation="tree_path_dependent")
     assert shap_elimination.fitted
     shap_elimination._check_if_fitted()
 

--- a/tests/interpret/test_model_interpret.py
+++ b/tests/interpret/test_model_interpret.py
@@ -65,8 +65,8 @@ def expected_feature_importance():
         {
             "mean_abs_shap_value_test": [0.5, 0.0, 0.0],
             "mean_abs_shap_value_train": [0.5, 0.0, 0.0],
-            "mean_shap_value_test": [-0.5, 0.0, 0.0],
-            "mean_shap_value_train": [-0.5, 0.0, 0.0],
+            "mean_shap_value_test": [0.0, 0.0, 0.0],
+            "mean_shap_value_train": [0.0, 0.0, 0.0],
         },
         index=["col_3", "col_1", "col_2"],
     )

--- a/tests/interpret/test_model_interpret.py
+++ b/tests/interpret/test_model_interpret.py
@@ -65,8 +65,8 @@ def expected_feature_importance():
         {
             "mean_abs_shap_value_test": [0.5, 0.0, 0.0],
             "mean_abs_shap_value_train": [0.5, 0.0, 0.0],
-            "mean_shap_value_test": [0.0, 0.0, 0.0],
-            "mean_shap_value_train": [0.0, 0.0, 0.0],
+            "mean_shap_value_test": [-0.5, 0.0, 0.0],
+            "mean_shap_value_train": [-0.5, 0.0, 0.0],
         },
         index=["col_3", "col_1", "col_2"],
     )


### PR DESCRIPTION
Fixes #170 

With this change a workaround for the issue https://github.com/slundberg/shap/issues/480 is proposed.

The workaround consists in not passing any masking data when `feature_perturbation` is explicitly set to `tree_path_dependent` in the `fit_compute` method or when the dataset contains categorical features. This will force shap explainer to use the `tree_path_dependent` strategy (instead of `interventional`), which supports categorical features explanation and should not raise the exception:

```
AttributeError: 'TreeEnsemble' object has no attribute 'values'
```

A very nice explanation of the differences between `tree_path_dependent` and `interventional` can be found here https://github.com/slundberg/shap/issues/1098#issuecomment-599622022.