### PR TITLE
Compatibility early stopping with old lgbm

### DIFF
--- a/probatus/feature_elimination/feature_elimination.py
+++ b/probatus/feature_elimination/feature_elimination.py
@@ -979,7 +979,11 @@ class EarlyStoppingShapRFECV(ShapRFECV):
         Returns:
             dict: fit parameters
         """
-        from lightgbm import early_stopping, log_evaluation
+        try:
+            from lightgbm import early_stopping, log_evaluation
+        except: # For LGBM < 3.3.0
+            from lightgbm import early_stopping, print_evaluation as log_evaluation
+
 
         fit_params = {
             "X": X_train,

--- a/probatus/feature_elimination/feature_elimination.py
+++ b/probatus/feature_elimination/feature_elimination.py
@@ -981,7 +981,7 @@ class EarlyStoppingShapRFECV(ShapRFECV):
         """
         try:
             from lightgbm import early_stopping, log_evaluation
-        except: # For LGBM < 3.3.0
+        except ImportError: # For LGBM < 3.3.0
             from lightgbm import early_stopping, print_evaluation as log_evaluation
 
 


### PR DESCRIPTION
Fixes #187 

'lightgbm.print_evaluation' was renamed to 'log_evaluation' after lgbm 3.3.0