### PR TITLE
Remove unnecessary rounding of metrics.

### DIFF
--- a/probatus/feature_elimination/feature_elimination.py
+++ b/probatus/feature_elimination/feature_elimination.py
@@ -575,10 +575,10 @@ class ShapRFECV(BaseFitComputePlotClass):
                 round_number=round_number,
                 current_features_set=current_features_set,
                 features_to_remove=features_to_remove,
-                train_metric_mean=np.round(np.mean(scores_train), 3),
-                train_metric_std=np.round(np.std(scores_train), 3),
-                val_metric_mean=np.round(np.mean(scores_val), 3),
-                val_metric_std=np.round(np.std(scores_val), 3),
+                train_metric_mean=np.mean(scores_train),
+                train_metric_std=np.std(scores_train),
+                val_metric_mean=np.mean(scores_val),
+                val_metric_std=np.std(scores_val),
             )
             if self.verbose > 50:
                 print(


### PR DESCRIPTION
Rounding reported metrics to 3 decimals unnecessarily removes granularity that some users may need. It's better to remove this.

Resolves #190
Closes #190