### PR TITLE
Fixes the use of eval_metric in case of EarlyStoppingShapRFECV with LightGBM

### DIFF
--- a/.github/workflows/cronjob_unit_tests.yml
+++ b/.github/workflows/cronjob_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
             os: ubuntu-latest
           - build: windows
             os: windows-latest
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@master
 
@@ -30,6 +30,11 @@ jobs:
       with:
         cmakeVersion: latest
         ninjaVersion: latest
+
+    - name: Install LIBOMP on Macos runners
+      if: runner.os == 'macOS'
+      run: |
+        brew install libomp
 
     - name: Setup Python
       uses: actions/setup-python@master

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,7 @@ jobs:
         ninjaVersion: latest
 
     - name: Install LIBOMP on Macos runners
-      if: ${{ matrix.os }} == 'macos'
+      if: runner.os == 'macOS'
       run: |
         brew install libomp
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
             os: ubuntu-latest
           - build: windows
             os: windows-latest
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,6 +30,11 @@ jobs:
         cmakeVersion: latest
         ninjaVersion: latest
 
+    - name: Install LIBOMP on Macos runners
+      if: ${{ matrix.os }} == "macos"
+      run: |
+        brew install libomp
+
     - name: Setup Python
       uses: actions/setup-python@master
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,7 @@ jobs:
         ninjaVersion: latest
 
     - name: Install LIBOMP on Macos runners
-      if: ${{ matrix.os }} == "macos"
+      if: ${{ matrix.os }} == 'macos'
       run: |
         brew install libomp
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
       - id: nbqa-isort
         name: "isort nb: Sort file imports"
       - id: nbqa-pyupgrade
-        name: "pyupgrade nb: Updates code to Python 3.8+ code convention"
-        args: [&py_version --py37-plus]
+        name: "pyupgrade nb: Updates code to Python 3.9+ code convention"
+        args: [&py_version --py38-plus]
       - id: nbqa-black
         name: "black nb: PEP8 compliant code formatter"
   - repo: local
@@ -55,5 +55,5 @@ repos:
     rev: v3.4.0
     hooks:
       - id: pyupgrade
-        name: "pyupgrade: Updates code to Python 3.8+ code convention"
+        name: "pyupgrade: Updates code to Python 3.9+ code convention"
         args: [*py_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,58 +2,58 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    - id: check-case-conflict # Different OSes
-      name: 'Check case conflict: Naming of files is compatible with all OSes'
-    - id: check-docstring-first
-      name: 'Check docstring first: Ensures Docstring present and first'
-    - id: detect-private-key
-      name: 'Detect private key: Prevent commit of env related keys'
-    - id: trailing-whitespace
-      name: 'Trailing whitespace: Remove empty spaces'
+      - id: check-case-conflict # Different OSes
+        name: "Check case conflict: Naming of files is compatible with all OSes"
+      - id: check-docstring-first
+        name: "Check docstring first: Ensures Docstring present and first"
+      - id: detect-private-key
+        name: "Detect private key: Prevent commit of env related keys"
+      - id: trailing-whitespace
+        name: "Trailing whitespace: Remove empty spaces"
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
+    rev: 1.8.5
     hooks:
-    - id: nbqa-ruff
-      name: 'ruff nb: Check for errors, styling issues and complexity'
-    - id: nbqa-mypy
-      name: 'mypy nb: Static type checking'
-    - id: nbqa-isort
-      name: 'isort nb: Sort file imports'
-    - id: nbqa-pyupgrade
-      name: 'pyupgrade nb: Updates code to Python 3.8+ code convention'
-      args: [&py_version --py37-plus]
-    - id: nbqa-black
-      name: 'black nb: PEP8 compliant code formatter'
+      - id: nbqa-ruff
+        name: "ruff nb: Check for errors, styling issues and complexity"
+      - id: nbqa-mypy
+        name: "mypy nb: Static type checking"
+      - id: nbqa-isort
+        name: "isort nb: Sort file imports"
+      - id: nbqa-pyupgrade
+        name: "pyupgrade nb: Updates code to Python 3.8+ code convention"
+        args: [&py_version --py37-plus]
+      - id: nbqa-black
+        name: "black nb: PEP8 compliant code formatter"
   - repo: local
     hooks:
-    - id: mypy
-      name: 'mypy: Static type checking'
-      entry: mypy
-      language: system
-      types: [python]
+      - id: mypy
+        name: "mypy: Static type checking"
+        entry: mypy
+        language: system
+        types: [python]
   - repo: local
     hooks:
-    - id: ruff-check
-      name: 'Ruff: Check for errors, styling issues and complexity, and fixes issues if possible (including import order)'
-      entry: ruff check
-      language: system
-      args: [ --fix, --no-cache ]
-    - id: ruff-format
-      name: 'Ruff: format code in line with PEP8'
-      entry: ruff format
-      language: system
-      args: [ --no-cache ]
+      - id: ruff-check
+        name: "Ruff: Check for errors, styling issues and complexity, and fixes issues if possible (including import order)"
+        entry: ruff check
+        language: system
+        args: [--fix, --no-cache]
+      - id: ruff-format
+        name: "Ruff: format code in line with PEP8"
+        entry: ruff format
+        language: system
+        args: [--no-cache]
   - repo: local
     hooks:
-    - id: codespell
-      name: 'codespell: Check for grammar'
-      entry: codespell
-      language: system
-      types: [python]
-      args: [-L mot] # Skip the word "mot"
+      - id: codespell
+        name: "codespell: Check for grammar"
+        entry: codespell
+        language: system
+        types: [python]
+        args: [-L mot] # Skip the word "mot"
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.4.0
     hooks:
-    - id: pyupgrade
-      name: 'pyupgrade: Updates code to Python 3.8+ code convention'
-      args: [*py_version]
+      - id: pyupgrade
+        name: "pyupgrade: Updates code to Python 3.8+ code convention"
+        args: [*py_version]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ This will allow you to quickly see if the work you made contains some adaptions 
 
 ## Standards
 
-- Python 3.8+
+- Python 3.9+
 - Follow [PEP8](http://pep8.org/) as closely as possible (except line length)
 - [google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/)
 - Git: Include a short description of *what* and *why* was done, *how* can be seen in the code. Use present tense, imperative mood

--- a/probatus/feature_elimination/early_stopping_feature_elimination.py
+++ b/probatus/feature_elimination/early_stopping_feature_elimination.py
@@ -239,6 +239,7 @@ class EarlyStoppingShapRFECV(ShapRFECV):
             "X": X_train,
             "y": y_train,
             "eval_set": [(X_val, y_val)],
+            "eval_metric": self.eval_metric,
             "callbacks": [
                 early_stopping(self.early_stopping_rounds, first_metric_only=True),
                 log_evaluation(1 if self.verbose >= 2 else 0),
@@ -507,14 +508,6 @@ class EarlyStoppingShapRFECV(ShapRFECV):
 
         # Due to deprecation issues (compatibility with Sklearn) set some params
         # like below, instead of through fit().
-        try:
-            from lightgbm import LGBMModel
-
-            if isinstance(model, LGBMModel):
-                model.set_params(eval_metric=self.eval_metric)
-        except ImportError:
-            pass
-
         try:
             from xgboost.sklearn import XGBModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "probatus"
-version = "3.1.0"
-requires-python= ">=3.8"
+version = "3.1.1"
+requires-python= ">=3.9"
 description = "Validation of regression & classifiers and data used to develop them"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -33,9 +32,8 @@ dependencies = [
     "scipy>=1.4.0",
     "joblib>=0.13.2",
     "tqdm>=4.41.0",
-    "shap==0.43.0 ; python_version == '3.8'",
-    "shap>=0.43.0 ; python_version != '3.8'",
-    "numpy>=1.23.2,<2.0.0", # Numpy v2+ incompatibility. Update when 3.8 dropped.
+    "shap>=0.43.0",
+    "numpy>=1.23.2,<2.0.0",
     "numba>=0.57.0",
     "loguru>=0.7.2",
 ]
@@ -66,9 +64,7 @@ dev = [
     "codespell>=2.2.4",
     "ruff>=0.2.2",
     "lightgbm>=3.3.0",
-    # https://github.com/catboost/catboost/issues/2371
-    "catboost>=1.2 ; python_version != '3.8'",
-    "catboost<1.2 ; python_version == '3.8'",
+    "catboost>=1.2",
     "xgboost>=1.5.0",
     "scipy>=1.4.0",
 ]
@@ -93,7 +89,7 @@ isort = ["--profile=black"]
 black = ["--line-length=120"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 ignore_missing_imports = true
 namespace_packages = true
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "tqdm>=4.41.0",
     "shap==0.43.0 ; python_version == '3.8'",
     "shap>=0.43.0 ; python_version != '3.8'",
-    "numpy>=1.23.2",
+    "numpy>=1.23.2,<2.0.0", # Numpy v2+ incompatibility. Update when 3.8 dropped.
     "numba>=0.57.0",
     "loguru>=0.7.2",
 ]


### PR DESCRIPTION
This fixes issue #259 in the exact way described in the issue. 

It indeed removes the warning and uses the defined `eval_metric` in case of LightGBM. I have no idea how to "formally" test that. @ReinierKoops  please advice.