### PR TITLE
Weekly cronjob no longer tests notebooks (for now)

### DIFF
--- a/.github/workflows/cronjob_unit_tests.yml
+++ b/.github/workflows/cronjob_unit_tests.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Run (unit) tests
       env:
-        TEST_NOTEBOOKS: 1
+        TEST_NOTEBOOKS: 0
       run: |
         pytest --cov=probatus/binning --cov=probatus/metric_volatility --cov=probatus/missing_values --cov=probatus/sample_similarity --cov=probatus/stat_tests --cov=probatus/utils --cov=probatus/interpret/ --ignore==tests/interpret/test_inspector.py --cov-report=xml
         pyflakes probatus


### PR DESCRIPTION
As of right now, our unit tests for notebooks are unreliable and as a result we get false positives. Therefore it is proposed to disable it for now until we have a better solution how to fix the notebook tests (which are a bit more extensive examples than normal unit test).