### PR TITLE
fixed group CV in hyperparameter tuning

### DIFF
--- a/probatus/feature_elimination/feature_elimination.py
+++ b/probatus/feature_elimination/feature_elimination.py
@@ -252,6 +252,7 @@ class ShapRFECV(BaseFitComputePlotClass):
         sample_weight=None,
         columns_to_keep=None,
         column_names=None,
+        groups=None,
         shap_variance_penalty_factor=None,
         **shap_kwargs,
     ):
@@ -314,6 +315,7 @@ class ShapRFECV(BaseFitComputePlotClass):
             sample_weight=sample_weight,
             columns_to_keep=columns_to_keep,
             column_names=column_names,
+            groups=groups,
             shap_variance_penalty_factor=shap_variance_penalty_factor,
             **shap_kwargs,
         )
@@ -452,7 +454,7 @@ class ShapRFECV(BaseFitComputePlotClass):
 
             # Optimize parameters
             if self.search_model:
-                current_search_model = clone(self.model).fit(current_X, self.y)
+                current_search_model = clone(self.model).fit(X=current_X, y=self.y, groups=groups)
                 current_model = current_search_model.estimator.set_params(**current_search_model.best_params_)
             else:
                 current_model = clone(self.model)


### PR DESCRIPTION
While ShapRFECV was already compatible with group cross-validation (e.g., GroupKFold, LeaveOneGroupOut), hyperparameter tuning was not; even if a group cross-validation generator is passed to the hyperparameter tuner (e.g., GridSearchCV, RandomizedSearchCV, BayesSearchCV).

To correct this, `probatus/feature_elimination/feature_elimination.py` was modified to ensure the groups argument can be defined when calling both `fit()` and `fit_compute()` from `ShapRFECV`, and is actually passed into the model's `fit()` method. The change was done such that cross-validation schemes independent from data groups still work.

Ensuring groups are kept separate in training and validation data also during hyperparameter tuning is important in some applications, e.g., medical, to promote model parameters which robustly predict out-of-group samples.