### PR TITLE
Fix sklearn API breakage when using search models with groups

### DIFF
--- a/probatus/feature_elimination/feature_elimination.py
+++ b/probatus/feature_elimination/feature_elimination.py
@@ -454,7 +454,7 @@ class ShapRFECV(BaseFitComputePlotClass):
 
             # Optimize parameters
             if self.search_model:
-                current_search_model = clone(self.model).fit(X=current_X, y=self.y, groups=groups)
+                current_search_model = clone(self.model).fit(current_X, self.y)
                 current_model = current_search_model.estimator.set_params(**current_search_model.best_params_)
             else:
                 current_model = clone(self.model)


### PR DESCRIPTION
Fixes #278.

PR #275 added `groups=groups` to the search model's `.fit()` call (line 457). This breaks on sklearn 1.7+ where metadata routing is enabled by default - `RandomizedSearchCV.fit` and `GridSearchCV.fit` reject `groups` as an unexpected argument.

The fix reverts that call to `clone(self.model).fit(current_X, self.y)`. The `groups` parameter is only needed for the outer CV splits (lines 475/489), not for the inner hyperparameter search which runs its own internal CV.

Tested with sklearn 1.6.1 + metadata routing enabled manually, and all 25 feature_elimination tests pass.