### PR TITLE
Fix CI workflow failures

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
             os: windows-latest
         python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Get latest CMake and Ninja
       uses: lukka/get-cmake@latest
@@ -36,7 +36,7 @@ jobs:
         brew install libomp
 
     - name: Setup Python
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -59,7 +59,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: github.ref == 'refs/heads/main'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
         entry: mypy
         language: system
         types: [python]
+        files: ^probatus/
   - repo: local
     hooks:
       - id: ruff-check


### PR DESCRIPTION
Fixes #281. Partially addresses #282.

Two changes:

**1. Pin GitHub Actions to stable versions**
`actions/checkout@master` and `actions/setup-python@master` no longer resolve, causing `startup_failure` on all PRs. Pinned to `@v4`/`@v5`. Also updated `codecov/codecov-action` from v1 to v4.

**2. Scope mypy pre-commit hook to probatus/ only**
mypy was scanning site-packages, failing on `match` statements in pytest internals because `python_version = "3.9"`. Added `files: ^probatus/` to the hook.

Verified on fork: https://github.com/detrin/probatus/actions/runs/23989798509 - CI starts and passes linting. Remaining test failures are pre-existing SHAP/XGBoost incompatibility.