### PR TITLE
Bump numpy version cap from <2.0.0 to <3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "matplotlib>=3.1.1",
     "joblib>=0.13.2",
     "shap>=0.43.0",
-    "numpy>=1.23.2,<2.0.0",
+    "numpy>=1.23.2,<3.0.0",
     "numba>=0.57.0",
     "loguru>=0.7.2",
 ]


### PR DESCRIPTION
Fixes #279.

The `numpy<2.0.0` cap makes probatus uninstallable alongside modern SHAP (>=0.50.0 requires numpy>=2). All dependencies now support numpy 2 - including CatBoost since v1.2.8.

Full test suite passes on numpy 2.0.2: 61 passed, 11 skipped, 0 failures.