### PR TITLE
Remove numba from direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "joblib>=0.13.2",
     "shap>=0.43.0",
     "numpy>=1.23.2,<2.0.0",
-    "numba>=0.57.0",
     "loguru>=0.7.2",
 ]
 


### PR DESCRIPTION
Fixes #283.

`numba` is not imported anywhere in probatus - it's only needed transitively through SHAP, which declares its own numba dependency. Removing it reduces install weight (numba pulls LLVM) and lowers the surface for version conflicts.

Full test suite passes: 61 passed, 11 skipped, 0 failures.